### PR TITLE
Change runs-on os for gitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Ubuntu can't build it properly.
After installing it by brew, the following error shows.

```
% screanswer
panic: clipboard: cannot use when CGO_ENABLED=0

goroutine 1 [running]:
golang.design/x/clipboard.initialize(...)
	/home/runner/go/pkg/mod/golang.design/x/clipboard@v0.7.0/clipboard_nocgo.go:9
golang.design/x/clipboard.Init.func1()
	/home/runner/go/pkg/mod/golang.design/x/clipboard@v0.7.0/clipboard.go:107 +0x27
sync.(*Once).doSlow(0x1e72108?, 0x140?)
	/opt/hostedtoolcache/go/1.20.3/x64/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	/opt/hostedtoolcache/go/1.20.3/x64/src/sync/once.go:65
golang.design/x/clipboard.Init()
	/home/runner/go/pkg/mod/golang.design/x/clipboard@v0.7.0/clipboard.go:106 +0x31
main.NewCaptureClient({0x1816ab8?, 0xc000040098})
	/home/runner/work/screanswer/screanswer/capture.go:40 +0x2c
main.init.0.func1(0xc00031f840)
	/home/runner/work/screanswer/screanswer/main.go:33 +0xf8
github.com/urfave/cli/v2.(*Command).Run(0xc0001a38c0, 0xc00031f840, {0xc000036250, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/command.go:274 +0x9eb
github.com/urfave/cli/v2.(*App).RunContext(0xc0001ce1e0, {0x1816ab8?, 0xc000040098}, {0xc000036250, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/app.go:332 +0x616
github.com/urfave/cli/v2.(*App).Run(...)
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/app.go:309
main.main()
	/home/runner/work/screanswer/screanswer/main.go:60 +0x47
```