### PR TITLE
Fix build for Apple Silicon

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,9 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - goos:
+  - env:
+      - CGO_ENABLED=1
+    goos:
       - darwin
 archives:
   - format: tar.gz


### PR DESCRIPTION
The job on macOS in GitHub Actions runs as x86_64 architecture.
The go build from the architecture to ARM architecture like Apple Silicon seems to use "CGO_ENABLED=0".
Therefore, this specifies "CGO_ENABLED=1" to avoid it.